### PR TITLE
Use environment variables to avoid funky errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,31 +47,42 @@ runs:
   using: composite
   steps:
     - name: Set up nox environments
+      env:
+        _ACTION_SESSIONS: ${{ inputs.sessions }}
+        _ACTION_FORCE_PYTHONS: ${{ inputs.force-pythons }}
+        _ACTION_CODECOV_SESSION: ${{ inputs.codecov-session }}
       run: >-
         echo "::group::Set up nox environments"
         ;
         nox -v
-        ${{ inputs.sessions && '--sessions ' || '' }}${{ inputs.sessions }}
-        ${{ inputs.codecov == 'true' && inputs.codecov-session || '' }}
-        ${{ inputs.force-pythons && '--force-python ' || '' }}${{ inputs.force-pythons }}
+        ${{ (inputs.sessions || inputs.codecov == 'true') && '--sessions ${_ACTION_SESSIONS}' || '' }}
+        ${{ inputs.codecov == 'true' && '${_ACTION_CODECOV_SESSION}' || '' }}
+        ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
         --install-only
         ;
         echo "::endgroup::"
       shell: bash
       working-directory: "${{ inputs.working-directory }}"
     - name: "Run nox -e ${{ matrix.session }}"
+      env:
+        _ACTION_SESSIONS: ${{ inputs.sessions }}
+        _ACTION_FORCE_PYTHONS: ${{ inputs.force-pythons }}
       run: >-
         nox -v
-        ${{ inputs.sessions && '--sessions ' || '' }}${{ inputs.sessions }}
-        ${{ inputs.force-pythons && '--force-python ' || '' }}${{ inputs.force-pythons }}
+        ${{ inputs.sessions && '--sessions ${_ACTION_SESSIONS}' || '' }}
+        ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
         --reuse-existing-virtualenvs
         --no-install
       shell: bash
       working-directory: "${{ inputs.working-directory }}"
     - name: Report coverage
       if: ${{ inputs.codecov == 'true' && inputs.codecov-session }}
+      env:
+        _ACTION_FORCE_PYTHONS: ${{ inputs.force-pythons }}
+        _ACTION_CODECOV_SESSION: ${{ inputs.codecov-session }}
       run: >-
-        nox -v -e ${{ inputs.codecov-session }}
+        nox -v -e ${_ACTION_CODECOV_SESSION}
+        ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
         --reuse-existing-virtualenvs
         --no-install
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,14 @@ runs:
       run: >-
         echo "::group::Set up nox environments"
         ;
+        echo "Run:
+        nox -v
+        ${{ (inputs.sessions || inputs.codecov == 'true') && '--sessions ${_ACTION_SESSIONS}' || '' }}
+        ${{ inputs.codecov == 'true' && '${_ACTION_CODECOV_SESSION}' || '' }}
+        ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
+        --install-only
+        "
+        ;
         nox -v
         ${{ (inputs.sessions || inputs.codecov == 'true') && '--sessions ${_ACTION_SESSIONS}' || '' }}
         ${{ inputs.codecov == 'true' && '${_ACTION_CODECOV_SESSION}' || '' }}
@@ -68,6 +76,14 @@ runs:
         _ACTION_SESSIONS: ${{ inputs.sessions }}
         _ACTION_FORCE_PYTHONS: ${{ inputs.force-pythons }}
       run: >-
+        echo "Run:
+        nox -v
+        ${{ inputs.sessions && '--sessions ${_ACTION_SESSIONS}' || '' }}
+        ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
+        --reuse-existing-virtualenvs
+        --no-install
+        "
+        ;
         nox -v
         ${{ inputs.sessions && '--sessions ${_ACTION_SESSIONS}' || '' }}
         ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
@@ -81,6 +97,13 @@ runs:
         _ACTION_FORCE_PYTHONS: ${{ inputs.force-pythons }}
         _ACTION_CODECOV_SESSION: ${{ inputs.codecov-session }}
       run: >-
+        echo "Run:
+        nox -v -e ${_ACTION_CODECOV_SESSION}
+        ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
+        --reuse-existing-virtualenvs
+        --no-install
+        "
+        ;
         nox -v -e ${_ACTION_CODECOV_SESSION}
         ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
         --reuse-existing-virtualenvs


### PR DESCRIPTION
https://github.com/ansible-community/antsibull-build/pull/659 fails because the session names contain `(` and `)`, which bash tries to interpret. Putting the session name in an env variable and using `${NAME_OF_ENV_VAR}` should fix it.