### PR TITLE
Add option to pass extra vars to sessions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
       Extra arguments to be passed to nox sessions. If empty, no extra arguments are passed.
       Can be a space-separated list of arguments
 
-      Example: `--check`
+      Example: `--check`.
   force-pythons:
     description: |-
       Which version(s) of Python to force. Should be a space-separated list of Python versions.

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   extra-args:
     description: |-
       Extra arguments to be passed to nox sessions. If empty, no extra arguments are passed.
-      Can be a space-separated list of arguments
+      Can be a space-separated list of arguments.
 
       Example: `--check`.
   force-pythons:

--- a/action.yml
+++ b/action.yml
@@ -85,10 +85,10 @@ runs:
       run: >-
         echo "Run:
         nox -v
+        ${{ inputs.sessions  && '--sessions ${_ACTION_SESSIONS}' || '' }}
         ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
         --reuse-existing-virtualenvs
         --no-install
-        ${{ inputs.sessions  && '--sessions ${_ACTION_SESSIONS}' || '' }}
         ${{ inputs.extra-args  && '-- ${_SESSION_ARGS}' || '' }}
         "
         ;

--- a/action.yml
+++ b/action.yml
@@ -81,15 +81,15 @@ runs:
       env:
         _ACTION_SESSIONS: ${{ inputs.sessions }}
         _ACTION_FORCE_PYTHONS: ${{ inputs.force-pythons }}
-        _SESSION_ARGS: ${{ inputs.extra-args }}
+        _ACTION_EXTRA_ARGS: ${{ inputs.extra-args }}
       run: >-
         echo "Run:
         nox -v
-        ${{ inputs.sessions  && '--sessions ${_ACTION_SESSIONS}' || '' }}
+        ${{ inputs.sessions && '--sessions ${_ACTION_SESSIONS}' || '' }}
         ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
         --reuse-existing-virtualenvs
         --no-install
-        ${{ inputs.extra-args  && '-- ${_SESSION_ARGS}' || '' }}
+        ${{ inputs.extra-args && '-- ${_ACTION_EXTRA_ARGS}' || '' }}
         "
         ;
         nox -v

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,12 @@ inputs:
 
       Example: `formatters codeqa`.
     default: ''
+  extra-args:
+    description: |-
+      Extra arguments to be passed to nox sessions. If empty, no extra arguments are passed.
+      Can be a space-separated list of arguments
+
+      Example: `--check`
   force-pythons:
     description: |-
       Which version(s) of Python to force. Should be a space-separated list of Python versions.
@@ -75,13 +81,15 @@ runs:
       env:
         _ACTION_SESSIONS: ${{ inputs.sessions }}
         _ACTION_FORCE_PYTHONS: ${{ inputs.force-pythons }}
+        _SESSION_ARGS: ${{ inputs.extra-args }}
       run: >-
         echo "Run:
         nox -v
-        ${{ inputs.sessions && '--sessions ${_ACTION_SESSIONS}' || '' }}
         ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
         --reuse-existing-virtualenvs
         --no-install
+        ${{ inputs.sessions  && '--sessions ${_ACTION_SESSIONS}' || '' }}
+        ${{ inputs.extra-args  && '-- ${_SESSION_ARGS}' || '' }}
         "
         ;
         nox -v


### PR DESCRIPTION
Reordered lines in the `run` block to move `--session ${{ inputs.sessions }}` to the end, allowing the addition of `-- ${{ inputs.extra-args }}` for sessions that need extra arguments passed.