### PR TITLE
Updated README to document new `extra-args` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ The follow options can be provided to this GitHub Action.
   </tr>
   <tr>
     <td>
+      <code>extra-args</code>
+      <br>
+      (default:&nbsp;<code>""</code>)
+    </td>
+    <td>
+      Extra arguments to pass to all sessions. If left empty, no additional arguments will be passed
+      <br>
+      Example: <code>--check</code>.
+    </td>
+  </tr>
+  <tr>
+    <td>
       <code>force-pythons</code>
       <br>
       (default:&nbsp;<code>""</code>)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The follow options can be provided to this GitHub Action.
       (default:&nbsp;<code>""</code>)
     </td>
     <td>
-      Extra arguments to pass to all sessions. If left empty, no additional arguments will be passed
+      Extra arguments to be passed to nox sessions. If empty, no extra arguments are passed. Can be a space-separated list of arguments.
       <br>
       Example: <code>--check</code>.
     </td>


### PR DESCRIPTION
Addressed #7. Adding to documentation of new `extra-args` option to README.

Happy to adjust wording if the team thinks there's a way to make this more clear.