### PR TITLE
Fix extra-args handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+---
+# Copyright (c) 2025 Maxwell G <maxwell@gtmx.me>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+"on":
+  push:
+  pull_request:
+  workflow_dispatch:
+
+name: Test this action
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Test ourselves
+    steps:
+      - uses: actions/checkout@v5
+      # Keep in sync with nox version in the README example
+      - name: Install nox
+        uses: wntrblm/nox@2025.10.16
+
+      - name: Test extra_args
+        uses: ./
+        with:
+          sessions: extra_args
+          working-directory: test
+          extra-args: hello

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use the action, add the following step to your workflow file (for example `.g
     working-directory: my-code
 
 - name: Install nox
-  uses: wntrblm/nox@2025.02.09
+  uses: wntrblm/nox@2025.10.16
   with:
     python-versions: "3.11, 3.12, 3.13"
 

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,7 @@ runs:
         _ACTION_SESSIONS: ${{ inputs.sessions }}
         _ACTION_FORCE_PYTHONS: ${{ inputs.force-pythons }}
         _ACTION_CODECOV_SESSION: ${{ inputs.codecov-session }}
+        _ACTION_EXTRA_ARGS: ${{ inputs.extra-args }}
       run: >-
         echo "::group::Set up nox environments"
         ;
@@ -66,6 +67,7 @@ runs:
         ${{ inputs.codecov == 'true' && '${_ACTION_CODECOV_SESSION}' || '' }}
         ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
         --install-only
+        ${{ inputs.extra-args && '-- ${_ACTION_EXTRA_ARGS}' || '' }}
         "
         ;
         nox -v
@@ -73,6 +75,7 @@ runs:
         ${{ inputs.codecov == 'true' && '${_ACTION_CODECOV_SESSION}' || '' }}
         ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
         --install-only
+        ${{ inputs.extra-args && '-- ${_ACTION_EXTRA_ARGS}' || '' }}
         ;
         echo "::endgroup::"
       shell: bash
@@ -97,6 +100,7 @@ runs:
         ${{ inputs.force-pythons && '--force-python ${_ACTION_FORCE_PYTHONS}' || '' }}
         --reuse-existing-virtualenvs
         --no-install
+        ${{ inputs.extra-args && '-- ${_ACTION_EXTRA_ARGS}' || '' }}
       shell: bash
       working-directory: "${{ inputs.working-directory }}"
     - name: Report coverage

--- a/test/noxfile.py
+++ b/test/noxfile.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Maxwell G <maxwell@gtmx.me>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import nox
+
+
+@nox.session
+def extra_args(session: nox.Session) -> None:
+    expected = ["hello"]
+    if session.posargs != expected:
+        session.error(f"Expected session.posargs {expected}, got {session.posargs}")


### PR DESCRIPTION
The current code doesn't actually pass the extra args to nox. The action echos the command about to be run before running it, and #6 only updates the `echo` part, not the actual command being run.

Also, it would be good to also pass the args when installing the session dependencies as some sessions may make decisions about what to install based on the arguments passed (I've written nox sessions before that does this, but it's probably not super common).

Fixes: https://github.com/ansible-community/github-action-run-nox/pull/6